### PR TITLE
Rename repository methods to align with standardized names

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ def unsubscribe():
     account_id = auth.get_account_id()
     with DB_ENGINE.connect() as conn:
         account_repo = DbAccountRepository(conn)
-        account_repo.end_subscription_for_account(account_id)
+        account_repo.remove_subscription_for_account(account_id)
         conn.commit()
 
     return redirect(url_for("home", error_description="Sorry to see you go. You have been unsubscribed"))
@@ -107,7 +107,7 @@ def unsubscribe():
 def email_unsubscribe(newsletter_id):
     with DB_ENGINE.connect() as conn:
         account_repo = DbAccountRepository(conn)
-        account_repo.end_subscription_for_account(auth.get_account_id())
+        account_repo.remove_subscription_for_account(auth.get_account_id())
         conn.commit()
     return redirect(url_for("home", error_description="Sorry to see you go. You have been unsubscribed"))
 
@@ -118,7 +118,7 @@ def subscribe():
     account_id = auth.get_account_id()
     with DB_ENGINE.connect() as conn:
         account_repo = DbAccountRepository(conn)
-        account_repo.create_subscription_for_account(account_id)
+        account_repo.store_subscription_for_account(account_id)
         conn.commit()
 
     return redirect(url_for("home", error_description="You have been subscribed!"))
@@ -220,7 +220,7 @@ def topics():
             account_id = auth.get_account_id()
             topic_prefs = []
             for topic in GENERAL_TOPICS:
-                entity_id = repo.lookup_entity_by_name(topic)
+                entity_id = repo.fetch_entity_by_name(topic)
                 if entity_id is None:
                     continue
                 score = get_pref(topic)
@@ -235,7 +235,7 @@ def topics():
                         )
                     )
 
-            repo.insert_topic_preferences(account_id, topic_prefs)
+            repo.store_topic_preferences(account_id, topic_prefs)
             conn.commit()
             updated = True
 

--- a/db/postgres_db.py
+++ b/db/postgres_db.py
@@ -22,7 +22,7 @@ def get_or_make_account(email, source):
         account_repo = DbAccountRepository(conn)
         result = account_repo.fetch_account_by_email(email)
         if result is None:
-            result = account_repo.create_new_account(email, source)
+            result = account_repo.store_new_account(email, source)
             conn.commit()
         return {
             "account_id": result.account_id,
@@ -49,7 +49,7 @@ def get_account(account_id):
 def finish_consent(account_id, consent_version):
     with DB_ENGINE.connect() as conn:
         account_repo = DbAccountRepository(conn)
-        account_repo.record_consent(account_id, consent_version)
+        account_repo.store_consent(account_id, consent_version)
         account_repo.update_status(account_id, "pending_initial_preferences")
         conn.commit()
 
@@ -58,5 +58,5 @@ def finish_onboarding(account_id):
     with DB_ENGINE.connect() as conn:
         account_repo = DbAccountRepository(conn)
         account_repo.update_status(account_id, "onboarding_done")
-        account_repo.create_subscription_for_account(account_id)
+        account_repo.store_subscription_for_account(account_id)
         conn.commit()


### PR DESCRIPTION
We chose `store`/`fetch`/`update`/`remove` to describe the common actions, renamed the repository methods, and created aliases in `poprox-storage` for backward compatibility. This updates the method names to match so that we can remove the aliases.