### PR TITLE
Update `endpoint_url` to `recommender_url` for clarity

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,7 +323,7 @@ def onboarding_survey():
                         account_id=account_id,
                         profile_id=account_id,
                         group_id=None,
-                        endpoint_url=DEFAULT_RECS_ENDPOINT_URL,
+                        recommender_url=DEFAULT_RECS_ENDPOINT_URL,
                     )
                     return redirect(url_for("home", error_description="You have been subscribed!"))
 


### PR DESCRIPTION
This was broken by [a recent change](https://github.com/CCRI-POPROX/poprox-platform/commit/713b621c243061b590cf5255f4077c5cf070952c#diff-4f503f1772578b39c00f1c7e1cc44a5ed040afb0de1d70aa8d4c4ca165a76ff2R168) in `poprox-platform`