### PR TITLE
update_expt_assignment_to_opt_out

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from poprox_storage.repositories.account_interest_log import (
 )
 from poprox_storage.repositories.accounts import DbAccountRepository
 from poprox_storage.repositories.demographics import DbDemographicsRepository
+from poprox_storage.repositories.experiments import DbExperimentRepository
 
 from auth import Auth
 from db.postgres_db import (
@@ -108,16 +109,18 @@ def logout():
     auth.logout(error_description)
     return redirect(url_for("home"))
 
+
 @app.route(f"{URL_PREFIX}/opt_out_of_experiments")
 @auth.requires_login
 def opt_out_of_experiments():
     account_id = auth.get_account_id()
     with DB_ENGINE.connect() as conn:
-        account_repo = DbAccountRepository(conn)
+        account_repo = DbExperimentRepository(conn)
         account_repo.update_expt_assignment_to_opt_out(account_id)
         conn.commit()
-    
+
     return redirect(url_for("home", error_desctiption="You have been opted out of experiments"))
+
 
 @app.route(f"{URL_PREFIX}/unsubscribe")
 @auth.requires_login


### PR DESCRIPTION
The function `update_expt_assignment_to_opt_out( )` was in `poprox_storage.repositories.experiments`. In the earlier PR, I failed to notice that; however, it did not give me errors after running `app.py`. I have updated the code here.