### PR TITLE
Unsubscribe option typo fix

### DIFF
--- a/templates/pre_unsubscribe.html
+++ b/templates/pre_unsubscribe.html
@@ -75,7 +75,7 @@
             <div class="select">
                 <select id="sub-menu" name="sub-menu" onchange="handleSubMenuChange()">
                     <option value="">-- Select an option --</option>
-                    <option value="unsubscribe-without-any-removal">Unsubscribe from a POPROX emails.</option>
+                    <option value="unsubscribe-without-any-removal">Unsubscribe from all POPROX emails.</option>
                     <option value="remove-email">Unsubscribe and remove my name and email from POPROX system.</option>
                     <option value="remove-all-data">I want POPROX to remove all my data from the system.</option>
                 </select>


### PR DESCRIPTION
Bugfix:
"Unsubscribe from a POPROX emails." -> "Unsubscribe from all POPROX emails".