### PR TITLE
Add "Terms and Conditions" and "Privacy Policy" to the landing page

### DIFF
--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -30,16 +30,16 @@
 <div class="card">
 	<div class="card-body">
 		<h2 class="card-title">POPROX</h2>
-		<p class="card-text">POPROX is a personalized news service that delivers a daily, ad-free email newsletter featuring stories from the Associated Press, tailored to your interests.
+		<p class="card-text">POPROX is a personalized news service that delivers an ad-free daily email newsletter featuring stories from the Associated Press, tailored to your interests.
 			The service is free, and your email will remain private.
 			POPROX, which stands for Platform for OPen Recommendation and Online eXperimentation, was developed at the University of Minnesota with support from four other universities.
-			This project enables researchers to test new algorithms and presentation methods for news.
+			This project enables researchers to test news recommendation algorithms and presentation methods.
 			Occasionally, you will be asked to provide feedback on your experience with POPROX and the news content.
 		</p>
 
 		<h2 class="card-title">Getting Started</h2>
-		<p class="card-text">If you're already receiving POPROX emails and want to adjust your settings, please click the link at the bottom of any POPROX email.	</p>
-		<p class="card-text">To enroll, please provide your email address and confirm that you qualify:</p>
+		<p class="card-text">As a research project, the POPROX Terms and Conditions and Privacy Policy are described in our <a href="https://user.poprox.ai/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate in Research Agreement</a>. We'll walk you through the sections step-by-step in the next part of the onboarding process.</p>
+		<p class="card-text">First, please provide your email address and confirm that you qualify to participate in research studies:</p>
 	</div>
 	<div class="card-body">
 		<form action="{{url_for('pre_enroll_post')}}" method="post">
@@ -62,6 +62,7 @@
 			</div>
 			<button type="submit" class="btn btn-primary mt-3">Submit</button>
 		</form>
+		
 	</div>
 </div>
 


### PR DESCRIPTION
These are apparently required in order to get ads accepted by Reddit. Since we're a research project and not a company, this change mentions both of the exact phrases that are apparently required but points people to the Informed Consent to Participate In Research Agreement (i.e. the PDF of what we show on the later consent screen.)