### PR TITLE
Rework the landing page text and appearance

### DIFF
--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -19,6 +19,7 @@ body {
     background-color: #ffffff;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     flex-grow:0;
+    max-height: 80px;
 }
 
 .navbar-brand {
@@ -26,6 +27,10 @@ body {
     color: #ffffff !important;
     font-size: 1.8rem;
     letter-spacing: 1px;
+}
+
+.navbar .logo {
+    max-height: 70px;
 }
 
 .nav-link {

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -79,7 +79,6 @@ footer {
 
 .card-body {
     padding: 10px;
-    margin-bottom: 20px;
 }
 
 /* Buttons */

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -13,11 +13,11 @@ body {
     /* background-image: url("/img/background.jpg"); */
 }
 
-/* Navigation Bar */
-
-.navbar.bg-dark {
+.bg-dark {
     background-color: #212A37 !important;
 }
+
+/* Navigation Bar */
 
 .navbar {
     background-color: #f8f8ff;

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -71,7 +71,11 @@ footer {
     /* text-align: center; */
     transition: all 0.3s ease-in-out;
     margin-bottom: 20px;
+}
 
+.card-body {
+    padding: 10px;
+    margin-bottom: 20px;
 }
 
 /* Buttons */

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -1,8 +1,8 @@
 /* General Styles */
 body {
     /* font-family: ui-monospace; */
-    background-color: #ffffff;
-    color: #000000;
+    background-color: #f8f8ff;
+    color: #212A37;
     margin: 0;
     padding: 0;
     min-height: 100vh;
@@ -15,8 +15,12 @@ body {
 
 /* Navigation Bar */
 
+.navbar.bg-dark {
+    background-color: #212A37 !important;
+}
+
 .navbar {
-    background-color: #ffffff;
+    background-color: #f8f8ff;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     flex-grow:0;
     max-height: 80px;
@@ -24,7 +28,7 @@ body {
 
 .navbar-brand {
     font-weight: bold;
-    color: #ffffff !important;
+    color: #f8f8ff !important;
     font-size: 1.8rem;
     letter-spacing: 1px;
 }
@@ -34,7 +38,7 @@ body {
 }
 
 .nav-link {
-    color: #ffffff !important;
+    color: #f8f8ff !important;
     font-weight: 500;
 }
 
@@ -49,8 +53,8 @@ body>div {
 /* Footer */
 
 footer {
-    background-color: #000000;
-    color: #000000;
+    background-color: #212A37;
+    color: #f8f8ff;
     padding: 15px;
     text-align: center;
     font-size: 1rem;
@@ -65,7 +69,7 @@ footer {
     border: none;
     border-radius: 15px;
     background-color: #a3abbd22;
-    color: #000000;
+    color: #212A37;
     box-shadow: 0 6px 12px #a3abbd99;
     padding: 15px;
     /* text-align: center; */

--- a/templates/new-layout.html
+++ b/templates/new-layout.html
@@ -22,7 +22,7 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/">POPROX</a>
+            <img class="logo" src="{{url_for('static', filename='POPROX24-temp00A-01.svg')}}" alt="logo">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -40,15 +40,6 @@
         </div>
     </nav>
     <div class="container">
-        <div class="row align-items-center">
-            <!-- Image Section -->
-            <div class="row-md-6 text-center">
-                <img src="{{url_for('static', filename='POPROX24-temp00A-01.svg')}}" alt="logo" width="60%">
-            </div>
-        </div>
-        <!-- <div class="block box">
-            POPROX Newsletter
-        </div> -->
         <div class="container py-3">
             <div class="row">
                 {% block sidebar %}

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -30,7 +30,7 @@
 <div class="card">
 	<div class="card-body">
 		<h2 class="card-title text-center">Stay Informed, Your Way</h2>
-		<h4 class="card-title text-center">Get the news that matters to you in an ad-free daily newsletter with Associated Press articles personalized to your interests</h4>
+		<h4 class="card-title text-center">Get the news that matters to you in an ad-free daily newsletter with AP News articles personalized to your interests</h4>
 	</div>
 	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -29,9 +29,9 @@
 {% endif %}
 <div class="card">
 	<div class="card-body">
-		<h5 class="card-tile">What's POPROX?</h5>
-		<p>POPROX is a news recommendation research platform that helps
-			academic researchers learn how to recommend news that's engaging and relevant for you.
+		<h5 class="card-title">What's POPROX?</h5>
+		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in journalism and news.
+			It's funded by the National Science Foundation, and was developed at the University of Minnesota with support from several other universities.
 		</p>
 
 		<h5 class="card-title">What's In It For Me?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -35,7 +35,11 @@
 	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>
 		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
-			It's funded by the National Science Foundation, and was developed at the University of Minnesota with support from several other universities.
+			It's funded by the National Science Foundation and developed at the University of Minnesota.
+		</p>
+
+		<h5 class="card-title">How Does It Work?</h5>
+		<p class="card-text">Each day, we use your interests, reading history, and feedback to select the most interesting and engaging AP News articles just for you.
 		</p>
 
 		<h5 class="card-title">How Do I Sign Up?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -61,7 +61,7 @@
 					I am legally considered an adult
 				</label>&nbsp;&nbsp;<span class="hint--top-left hint--large" aria-label="In most of the United states this means you are at least 18 years old, except in Alabama and Nebraska where adulthood begins at 19 or in Mississippi and Puerto Rico where it begins at 21">(?)</span>
 			</div>
-			<button type="submit" class="btn btn-primary mt-3">Submit</button>
+			<button type="submit" class="btn btn-primary mt-3">Subscribe</button>
 		</form>
 	</div>
 	<div class="card-body">

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -34,7 +34,7 @@
 	</div>
 	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>
-		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in journalism and news.
+		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
 			It's funded by the National Science Foundation, and was developed at the University of Minnesota with support from several other universities.
 		</p>
 

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -29,14 +29,13 @@
 {% endif %}
 <div class="card">
 	<div class="card-body">
+		<h2 class="card-title">Stay Informed, Your Way</h2>
+		<h4 class="card-title">Get the news that matters to you in an ad-free daily newsletter with Associated Press articles personalized to your interests</h4>
+	</div>
+	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>
 		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in journalism and news.
 			It's funded by the National Science Foundation, and was developed at the University of Minnesota with support from several other universities.
-		</p>
-
-		<h5 class="card-title">What's In It For Me?</h5>
-		<p class="card-text">POPROX delivers an ad-free personalized daily email newsletter featuring stories from
-			the Associated Press, tailored to your interests based on your reading, preferences, and feedback.
 		</p>
 
 		<h5 class="card-title">How Do I Sign Up?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -30,7 +30,7 @@
 <div class="card">
 	<div class="card-body">
 		<h2 class="card-title text-center">Stay Informed, Your Way</h2>
-		<h4 class="card-title text-center">Get the news that matters to you in an ad-free daily newsletter with AP News articles personalized to your interests</h4>
+		<h4 class="card-title text-center">The stories that matter to you delivered to your inbox daily—no ads, just news.</h4>
 	</div>
 	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -47,7 +47,7 @@
 			<input type="hidden" id="source" name="source" value="{{source}}" >
 			<input type="hidden" id="subsource" name="subsource" value="{{subsource}}" >
 			<div class="form-group row">
-				<input class="form-control col col-md-1"name="email" id="email" type="email" placeholder="Email" required autofocus>
+				<input class="form-control col col-md-1"name="email" id="email" type="email" placeholder="Email" required>
 			</div>
 			<div class="form-check">
 				<input type="checkbox" class="form-check-input" id="us_area" name="us_area" required >

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -32,9 +32,6 @@
 	<h5 class="card-title text-center">The stories that matter to you delivered to your inbox daily—no ads, just news.</h5>
 </div>
 <div class="card-body">
-	<img class="image-fluid mx-auto d-block" src="static/newsletter.png" width="90%">
-</div>
-<div class="card-body">
 
 	<h5 class="card-title">What's POPROX?</h5>
 	<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -29,8 +29,8 @@
 {% endif %}
 <div class="card">
 	<div class="card-body">
-		<h2 class="card-title">Stay Informed, Your Way</h2>
-		<h4 class="card-title">Get the news that matters to you in an ad-free daily newsletter with Associated Press articles personalized to your interests</h4>
+		<h2 class="card-title text-center">Stay Informed, Your Way</h2>
+		<h4 class="card-title text-center">Get the news that matters to you in an ad-free daily newsletter with Associated Press articles personalized to your interests</h4>
 	</div>
 	<div class="card-body">
 		<h5 class="card-title">What's POPROX?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -46,7 +46,8 @@
 			<input type="hidden" id="source" name="source" value="{{source}}" >
 			<input type="hidden" id="subsource" name="subsource" value="{{subsource}}" >
 			<div class="form-group row">
-				<input class="form-control col col-md-1"name="email" id="email" type="email" placeholder="Email" required>
+				<label for="email">Email:</label>
+				<input class="form-control col col-md-1" name="email" id="email" type="email" autocomplete="email" placeholder="Email" required>
 			</div>
 			<div class="form-check">
 				<input type="checkbox" class="form-check-input" id="us_area" name="us_area" required >

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -29,17 +29,17 @@
 {% endif %}
 <div class="card">
 	<div class="card-body">
-		<h2 class="card-tile">What's POPROX?</h2>
+		<h5 class="card-tile">What's POPROX?</h5>
 		<p>POPROX is a news recommendation research platform that helps
 			academic researchers learn how to recommend news that's engaging and relevant for you.
 		</p>
 
-		<h2 class="card-title">What's In It For Me?</h2>
+		<h5 class="card-title">What's In It For Me?</h5>
 		<p class="card-text">POPROX delivers an ad-free personalized daily email newsletter featuring stories from
 			the Associated Press, tailored to your interests based on your reading, preferences, and feedback.
 		</p>
 
-		<h2 class="card-title">How Do I Sign Up?</h2>
+		<h5 class="card-title">How Do I Sign Up?</h5>
 		<p class="card-text">Please provide your email address and confirm that you qualify to participate in research studies:</p>
 	</div>
 	<div class="card-body">
@@ -65,7 +65,7 @@
 		</form>
 	</div>
 	<div class="card-body">
-		<h2 class="card-title">What Else Should I Know?</h2>
+		<h5 class="card-title">What Else Should I Know?</h5>
 		<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
 			in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
 			in Research Agreement</a>.

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -27,54 +27,56 @@
 	<p>{{ error }}</p>
 </div>
 {% endif %}
-<div class="card">
-	<div class="card-body">
-		<h2 class="card-title text-center">Stay Informed, Your Way</h2>
-		<h4 class="card-title text-center">The stories that matter to you delivered to your inbox daily—no ads, just news.</h4>
-	</div>
-	<div class="card-body">
-		<h5 class="card-title">What's POPROX?</h5>
-		<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
-			It's funded by the National Science Foundation and developed at the University of Minnesota.
-		</p>
-
-		<h5 class="card-title">How Does It Work?</h5>
-		<p class="card-text">Each day, we use your interests, reading history, and feedback to select the most interesting and engaging AP News articles just for you.
-		</p>
-
-		<h5 class="card-title">How Do I Sign Up?</h5>
-		<p class="card-text">Please provide your email address and confirm that you qualify to participate in research studies:</p>
-	</div>
-	<div class="card-body">
-		<form action="{{url_for('pre_enroll_post')}}" method="post">
-			<input type="hidden" id="source" name="source" value="{{source}}" >
-			<input type="hidden" id="subsource" name="subsource" value="{{subsource}}" >
-			<div class="form-group row">
-				<label for="email">Email:</label>
-				<input class="form-control col col-md-1" name="email" id="email" type="email" autocomplete="email" placeholder="Email" required>
-			</div>
-			<div class="form-check">
-				<input type="checkbox" class="form-check-input" id="us_area" name="us_area" required >
-				<label  class="form-check-label" for="us_area">
-					I live in the United States.
-				</label>
-			</div>
-			<div class="form-check">
-				<input type="checkbox" class="form-check-input" id="legal_age" name="legal_age" required>
-				<label class="form-check-label" for="legal_age">
-					I am legally considered an adult
-				</label>&nbsp;&nbsp;<span class="hint--top-left hint--large" aria-label="In most of the United states this means you are at least 18 years old, except in Alabama and Nebraska where adulthood begins at 19 or in Mississippi and Puerto Rico where it begins at 21">(?)</span>
-			</div>
-			<button type="submit" class="btn btn-primary mt-3">Subscribe</button>
-		</form>
-	</div>
-	<div class="card-body">
-		<h5 class="card-title">What Else Should I Know?</h5>
-		<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
-			in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
-			in Research Agreement</a>.
-		</p>
-	</div>
+<div class="card-body">
+	<h2 class="card-title text-center">Stay Informed, Your Way</h2>
+	<h5 class="card-title text-center">The stories that matter to you delivered to your inbox daily—no ads, just news.</h5>
 </div>
+<div class="card-body">
+	<img class="image-fluid mx-auto d-block" src="static/newsletter.png" width="90%">
+</div>
+<div class="card-body">
+
+	<h5 class="card-title">What's POPROX?</h5>
+	<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
+		It's funded by the National Science Foundation and developed at the University of Minnesota.
+	</p>
+
+	<h5 class="card-title">How Does It Work?</h5>
+	<p class="card-text">Each day, we use your interests, reading history, and feedback to select the most interesting and engaging AP News articles just for you.
+	</p>
+
+	<h5 class="card-title">How Do I Sign Up?</h5>
+	<p class="card-text">Please provide your email address and confirm that you qualify to participate in research studies:</p>
+
+	<form action="{{url_for('pre_enroll_post')}}" method="post">
+		<input type="hidden" id="source" name="source" value="{{source}}" >
+		<input type="hidden" id="subsource" name="subsource" value="{{subsource}}" >
+		<div class="form-group row">
+			<label for="email">Email:</label>
+			<input class="form-control col col-md-1" name="email" id="email" type="email" autocomplete="email" placeholder="Email" required>
+		</div>
+		<div class="form-check">
+			<input type="checkbox" class="form-check-input" id="us_area" name="us_area" required >
+			<label  class="form-check-label" for="us_area">
+				I live in the United States.
+			</label>
+		</div>
+		<div class="form-check">
+			<input type="checkbox" class="form-check-input" id="legal_age" name="legal_age" required>
+			<label class="form-check-label" for="legal_age">
+				I am legally considered an adult
+			</label>&nbsp;&nbsp;<span class="hint--top-left hint--large" aria-label="In most of the United states this means you are at least 18 years old, except in Alabama and Nebraska where adulthood begins at 19 or in Mississippi and Puerto Rico where it begins at 21">(?)</span>
+		</div>
+		<button type="submit" class="btn btn-primary mt-3">Subscribe</button>
+	</form>
+</div>
+<div class="card-body">
+	<h5 class="card-title">What Else Should I Know?</h5>
+	<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
+		in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
+		in Research Agreement</a>.
+	</p>
+</div>
+
 
 {% endblock %}

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -30,26 +30,17 @@
 <div class="card">
 	<div class="card-body">
 		<h2 class="card-tile">What's POPROX?</h2>
-		<p>Platform for OPen Recommendation and Online eXperimentation (POPROX) is a research platform that helps
-			academic researchers learn how to recommend news that's engaging and relevant for you by testing new
-			algorithms and presentation methods. It was developed at the University of Minnesota with support from
-			four other universities.
+		<p>POPROX is a news recommendation research platform that helps
+			academic researchers learn how to recommend news that's engaging and relevant for you.
 		</p>
 
 		<h2 class="card-title">What's In It For Me?</h2>
 		<p class="card-text">POPROX delivers an ad-free personalized daily email newsletter featuring stories from
 			the Associated Press, tailored to your interests based on your reading, preferences, and feedback.
-			The service is free, and your email will remain private. Occasionally, we'll ask you to provide feedback
-			on your experience with POPROX and the news articles we recommend.
 		</p>
 
 		<h2 class="card-title">How Do I Sign Up?</h2>
-		<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
-			in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
-			in Research Agreement</a>. We'll walk you through the sections of the agreement step-by-step in the next
-			part of the onboarding process.
-		</p>
-		<p class="card-text">First, please provide your email address and confirm that you qualify to participate in research studies:</p>
+		<p class="card-text">Please provide your email address and confirm that you qualify to participate in research studies:</p>
 	</div>
 	<div class="card-body">
 		<form action="{{url_for('pre_enroll_post')}}" method="post">
@@ -72,7 +63,13 @@
 			</div>
 			<button type="submit" class="btn btn-primary mt-3">Submit</button>
 		</form>
-
+	</div>
+	<div class="card-body">
+		<h2 class="card-title">What Else Should I Know?</h2>
+		<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
+			in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
+			in Research Agreement</a>.
+		</p>
 	</div>
 </div>
 


### PR DESCRIPTION
This involves a few changes:
* Moving the logo from the top of the page into the nav bar
* Putting the value proposition in a heading/subheading at the top
* Adding an image of an example newsletter
* Removing the card background (which narrows the width text can display across)
* Adjusting the colors to avoid pure black/white while maintaining accessible contrast
* Editing the text in each section so it only includes the essentials
* Moving information about the Consent Agreement _after_ the form (since almost no one reads it anyway)
* Removing auto-focus from the email field, which is nice on desktop but brings up a keyboard on mobile

This looks better on mobile, but has some issues on desktop, including a lot of screen real-estate left unused. We might consider things like using longer text, but since the majority of people are arriving on mobile I'm okay with punting that for now.

With these changes, the landing page looks like this:
![Screenshot-20250602140702-293x1205](https://github.com/user-attachments/assets/19b72661-af82-4e91-869f-415905ae6b19)
