### PR TITLE
Reverse the order of text sections on the landing page

### DIFF
--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -32,7 +32,7 @@
 	<h5 class="card-title text-center">The stories that matter to you delivered to your inbox daily—no ads, just news.</h5>
 </div>
 <div class="card-body">
-	<img class="image-fluid mx-auto d-block" src="static/example-newsletter.jpg" width="95%" style="max-width:400px;max-height:600px;">
+	<img class="image-fluid mx-auto d-block" src="static/example-newsletter.jpg" width="80%" style="max-width:400px;max-height:600px;">
 </div>
 <div class="card-body">
 	<h5 class="card-title">How Do I Sign Up?</h5>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -73,7 +73,7 @@
 	</p>
 
 	<h5 class="card-title">What Else Should I Know?</h5>
-	<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
+	<p class="card-text">As a research platform, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
 		in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate
 		in Research Agreement</a>.
 	</p>

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -35,16 +35,6 @@
 	<img class="image-fluid mx-auto d-block" src="static/example-newsletter.jpg" width="95%" style="max-width:400px;max-height:600px;">
 </div>
 <div class="card-body">
-
-	<h5 class="card-title">What's POPROX?</h5>
-	<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
-		It's funded by the National Science Foundation and developed at the University of Minnesota.
-	</p>
-
-	<h5 class="card-title">How Does It Work?</h5>
-	<p class="card-text">Every day we send you a newsletter with AP News articles curated just for you based on your interests, reading history, and feedback.
-	</p>
-
 	<h5 class="card-title">How Do I Sign Up?</h5>
 	<p class="card-text">Please provide your email address and confirm that you qualify to participate in research studies:</p>
 
@@ -71,6 +61,15 @@
 	</form>
 </div>
 <div class="card-body">
+	<h5 class="card-title">How Does It Work?</h5>
+	<p class="card-text">Every day we send you a newsletter with AP News articles curated just for you based on your interests, reading history, and feedback.
+	</p>
+
+	<h5 class="card-title">What's POPROX?</h5>
+	<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
+		It's funded by the National Science Foundation and developed at the University of Minnesota.
+	</p>
+
 	<h5 class="card-title">What Else Should I Know?</h5>
 	<p class="card-text">As a research project, the POPROX <a href="/static/Subscriber_Agreement_v2.pdf#page=1">Terms and Conditions</a> and <a href="/static/Subscriber_Agreement_v2.pdf#page=3">Privacy Policy</a> are described
 		in our <a href="/static/Subscriber_Agreement_v2.pdf">Informed Consent to Participate

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -62,12 +62,14 @@
 </div>
 <div class="card-body">
 	<h5 class="card-title">How Does It Work?</h5>
-	<p class="card-text">Every day we send you a newsletter with AP News articles curated just for you based on your interests, reading history, and feedback.
+	<p class="card-text">Each day we send you a newsletter with AP News articles curated just for you based on your interests, reading history, and feedback.
+		Occasionally, we'll ask you to fill out surveys about your experience with the newsletter and the articles we recommend.
 	</p>
 
 	<h5 class="card-title">What's POPROX?</h5>
 	<p>POPROX is a news recommendation research platform that helps researchers learn about the role of personalization in news and journalism.
-		It's funded by the National Science Foundation and developed at the University of Minnesota.
+		It's funded by the National Science Foundation and developed at the University of Minnesota with support from several other universities.
+		The information we collect helps us carry out research studies to shape the future of news recommendation.
 	</p>
 
 	<h5 class="card-title">What Else Should I Know?</h5>


### PR DESCRIPTION
This allows us to put the sign-up form first so that we don't lose anyone who was already sold before reading more about the project, and also allows us to expand the text to say a bit more about the project for anyone who wants to know more before deciding.

With these changes, the landing page looks like this on mobile:
![Screenshot-20250604152051-293x1205](https://github.com/user-attachments/assets/5ac78b6e-3fc3-4d26-b978-6c43e56c357a)