### PR TITLE
added experiment dashboard

### DIFF
--- a/admin/admin_blueprint.py
+++ b/admin/admin_blueprint.py
@@ -3,12 +3,10 @@ from os import environ as env
 
 from flask import Blueprint, jsonify, render_template
 from flask_httpauth import HTTPBasicAuth
-from poprox_storage.aws import SESSION
+from poprox_storage.aws import DB_ENGINE, SESSION
 from poprox_storage.aws.cloudwatch import Cloudwatch
 from poprox_storage.repositories.accounts import DbAccountRepository
 from werkzeug.security import check_password_hash, generate_password_hash
-
-from db.postgres_db import DB_ENGINE
 
 admin = Blueprint("admin", __name__, template_folder="templates", url_prefix="/admin")
 auth = HTTPBasicAuth()

--- a/app.py
+++ b/app.py
@@ -19,8 +19,7 @@ from poprox_storage.repositories.images import DbImageRepository
 from poprox_storage.repositories.newsletters import DbNewsletterRepository
 
 from admin.admin_blueprint import admin
-from auth import Auth
-from db.postgres_db import DB_ENGINE, finish_consent, finish_onboarding, finish_topic_selection
+from experimenter.experimenter_blueprint import exp
 from poprox_concepts.api.tracking import LoginLinkData, SignUpToken
 from poprox_concepts.domain import AccountInterest
 from poprox_concepts.domain.account import COMPENSATION_CARD_OPTIONS, COMPENSATION_CHARITY_OPTIONS
@@ -34,6 +33,8 @@ from poprox_concepts.domain.demographics import (
 from poprox_concepts.domain.topics import GENERAL_TOPICS
 from poprox_concepts.internals import from_hashed_base64
 from static_web.blueprint import static_web
+from util.auth import auth
+from util.postgres_db import DB_ENGINE, finish_consent, finish_onboarding, finish_topic_selection
 
 COMPENSATION_OPTIONS = COMPENSATION_CARD_OPTIONS + COMPENSATION_CHARITY_OPTIONS + ["Decline payment"]
 
@@ -48,9 +49,9 @@ HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")
 ENROLL_TOKEN_TIMEOUT = timedelta(days=1)
 
 app.register_blueprint(admin)
+app.register_blueprint(exp)
 
 
-auth = Auth(app)
 app.register_blueprint(static_web)
 
 

--- a/experimenter/experimenter_blueprint.py
+++ b/experimenter/experimenter_blueprint.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, render_template
+
+from util.auth import auth
+
+exp = Blueprint("experimenter", __name__, template_folder="templates", url_prefix="/dash")
+
+
+@exp.route("/")
+@auth.requires_experimenter
+def expt_home():
+    return render_template("experimenter_home.html", experiments=auth.get_account_experiments())
+
+
+@exp.route("/<experiment_id>")
+@auth.requires_experiment_team
+def expt_dashboard(experiment_id):
+    return render_template("experiment_dashboard.html", experiment=auth.get_account_experiments()[experiment_id])

--- a/experimenter/templates/experiment_dashboard.html
+++ b/experimenter/templates/experiment_dashboard.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+
+
+
+</head>
+<body>
+    No content here yet! Here's your experiment metadata in one ugly json dump!
+    <pre>
+        <code>
+            {{experiment|tojson}}
+        </code>
+    </pre>
+</body>
+</html>

--- a/experimenter/templates/experimenter_home.html
+++ b/experimenter/templates/experimenter_home.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+
+
+
+</head>
+<body>
+    <ul>
+      {% for expt in experiments.values() %}
+      <li><a href="{{url_for('experimenter.expt_dashboard', experiment_id=expt.experiment_id)}}">{{expt.description}}</a></li>
+      {% endfor %}
+      </ul>
+</body>
+</html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -42,6 +42,9 @@
 
                                     <li><a href="{{url_for('topics')}}">Topic Selection</a></li> <!-- added topic selection link here -->
                                     <li><a href="{{url_for('onboarding_survey')}}">Demographics and Compensation</a></li> <!-- added user demographic link here -->
+                                    {% if auth.get_account_teams()|length > 0%}
+                                    <li><a href="{{url_for('experimenter.expt_home')}}">Experimenter Dashboard</a></li>
+                                    {% endif %}
                                 </ul>
                             {% else %}
                                 <p class="menu-label">


### PR DESCRIPTION
Depends on CCRI-POPROX/poprox-storage#108

The actual dashboard I put in is _terrible_ and I didn't bother making anything look even slightly good. Both of these choices are questionable, but we can clean it up later.

Right now accessing this for testing would mean clicking into the topics or setings in a newsletter that was sent to someone who is on a team in an experiment in the database. Success will mean getting a list of those experiments and the ability to click into any of them to get the experiment object dumped to json