### PR TITLE
add link tracking endpoint in web

### DIFF
--- a/app.py
+++ b/app.py
@@ -528,7 +528,7 @@ def onboarding_survey():
     )
 
 
-@app.route(f"{URL_PREFIX}/track/<path>", methods=["GET"])
+@app.route(f"{URL_PREFIX}/redirect/<path>", methods=["GET"])
 def track_email_click(path):
     try:
         headers = {k: v for k, v in request.headers.items()}  # convert to conventional dict


### PR DESCRIPTION
Currently this will have an error in validation hooks due to weirdness with the concepts repo and token code. This should resolve after the token PR is merged, if not at east once that lands I can look into merging it in and fixing whatever problems are left.

This does part 1/3 for switching over tracking to `poprox.ai` and `poprox-web`.
Parts 2 and 3 will be in poprox-platform and will want to happen after this lands.

For part 2 we either update environment variable `BASE_TRACKING_URL` at platform/ssm or we just hardcode the new tracking link. Then after enough time has passed that we don't think it'll get any further clicks we can remove the old tracking lambda

