### PR TITLE
Account management operator dashboard

### DIFF
--- a/admin/admin_blueprint.py
+++ b/admin/admin_blueprint.py
@@ -23,14 +23,24 @@ def verify_password(username, password):
         return username
 
 
-@admin.route("/")
+@admin.get("/")
 @admin_auth.login_required
 def show():
+    error = request.args.get("error")
+    return render_template("admin_home.html", error=error)
+
+
+### TEAM MANAGEMENT ###
+
+
+@admin.get("/team")
+@admin_auth.login_required
+def team_manage():
     error = request.args.get("error")
     with DB_ENGINE.connect() as conn:
         team_repo = DbTeamRepository(conn)
         teams = team_repo.fetch_teams()
-        return render_template("admin_home.html", error=error, teams=teams)
+        return render_template("admin_team_management.html", error=error, teams=teams)
 
 
 @admin.get("/team/<team_id>")
@@ -90,3 +100,34 @@ def new_team():
         team_repo.store_team(team)
         conn.commit()
         return redirect(url_for("admin.team_details", team_id=team.team_id))
+
+
+### ACCOUNT MANAGEMENT
+
+
+@admin.get("/account")
+@admin_auth.login_required
+def account_search():
+    accounts = []
+    with DB_ENGINE.connect() as conn:
+        account_repo = DbAccountRepository(conn)
+        if request.args.get("account_id"):
+            accounts = account_repo.fetch_accounts(request.args["account_id]"])
+        elif request.args.get("account_email_query"):
+            accounts = account_repo.fetch_account_by_email_query(request.args["account_email_query"])
+
+    return render_template("admin_account_management.html", accounts=accounts)
+
+
+@admin.get("/account/<account_id>")
+@admin_auth.login_required
+def account_detail(account_id):
+    with DB_ENGINE.connect() as conn:
+        account_repo = DbAccountRepository(conn)
+        account = account_repo.fetch_accounts([account_id])
+        if len(account) == 0:
+            redirect(url_for("admin.account_search", error="account not found"))
+        else:
+            account = account[0]
+
+    return render_template("admin_account_detail.html", account=account)

--- a/admin/templates/admin_account_detail.html
+++ b/admin/templates/admin_account_detail.html
@@ -1,0 +1,19 @@
+{% extends "admin_main_layout.html" %}
+
+
+
+{% block content %}
+
+  <h1>Account Management</h1>
+
+  <dl>
+  {% for key, value in account.model_dump().items() %}
+    <dt>{{key}}</dt>
+    <dd>{{value}}</dd>
+    {% if key == "source" %}
+      <dd>SOURCE</dd>
+    {% endif %}
+  {% endfor %}
+  </dl>
+
+  {% endblock %}

--- a/admin/templates/admin_account_detail.html
+++ b/admin/templates/admin_account_detail.html
@@ -5,15 +5,28 @@
 {% block content %}
 
   <h1>Account Management</h1>
-
-  <dl>
-  {% for key, value in account.model_dump().items() %}
-    <dt>{{key}}</dt>
-    <dd>{{value}}</dd>
-    {% if key == "source" %}
-      <dd>SOURCE</dd>
-    {% endif %}
-  {% endfor %}
-  </dl>
+  <form method="post" action="{{url_for('admin.update_account_detail', account_id = account.account_id)}}">
+    <dl>
+    {% for key, value in account.model_dump().items() %}
+      <dt>{{key}}</dt>
+      {% if key == "source" and account.internal %}
+        <dd>(INTERNAL)</dd>
+      {% endif %}
+      {% if key == "source" and account.external %}
+        <dd>(EXTERNAL)</dd>
+      {% endif %}
+      {% if key in editable %}
+        <dd>
+          <input value="{{value}}" id="{{key}}" name="{{key}}" placeholder="{{value}}">
+        </dd>
+      {% else %}
+        <dd>
+          {{value}}
+        </dd>
+      {% endif %}
+    {% endfor %}
+    </dl>
+    <input type="submit">
+  </form>
 
   {% endblock %}

--- a/admin/templates/admin_account_management.html
+++ b/admin/templates/admin_account_management.html
@@ -1,0 +1,26 @@
+{% extends "admin_main_layout.html" %}
+
+
+
+{% block content %}
+
+  <h1>Account Management</h1>
+
+  <h2>Account Search</h2>
+  <form action="{{url_for('admin.account_search')}}" method="GET">
+    <label for="account_email_query">SQL like syntax account search by email:</label><br>
+    <input id="account_email_query" name="account_email_query" value="{{request.args.account_email_query or ''}}">
+    <input type="submit">
+  </form>
+  <form action="{{url_for('admin.account_search')}}" method="GET">
+    <label for="account_id">direct match by id:</label><br>
+    <input id="account_id" name="account_id">
+    <input type="submit">
+  </form>
+
+  <ul>
+  {% for account in accounts %}
+    <li><a href="{{url_for('admin.account_detail', account_id=account.account_id)}}">{{account.email}}</a></li>
+  {% endfor %}
+  </ul>
+  {% endblock %}

--- a/admin/templates/admin_edit_team.html
+++ b/admin/templates/admin_edit_team.html
@@ -1,16 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+{% extends "admin_main_layout.html" %}
 
-</head>
-<body>
 
-  {% if error %}
-    <div class="error">{{error}}</div>
-  {% endif %}
+
+{% block content %}
 
   <h1>Team Management</h1>
   <h2>{{team.team_name}} ({{team.team_id}})</h2>
@@ -31,5 +23,4 @@
     <input type="email" id="email" name="email" placeholder="who">
     <input type="submit">
   </form>
-</body>
-</html>
+  {% endblock %}

--- a/admin/templates/admin_home.html
+++ b/admin/templates/admin_home.html
@@ -1,32 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-
-</head>
-<body>
-
-  {% if error %}
-    <div class="error">{{error}}</div>
-  {% endif %}
+{% extends "admin_main_layout.html" %}
 
 
-  <h1>Team Management</h1>
-  <table>
-    <tr><th>Team Name</th><th>Actions</th></tr>
-    {% for team in teams.values() %}
-    <tr>
-        <td>{{team.team_name}}</td>
-        <td><a href="{{url_for('admin.team_details', team_id=team.team_id)}}">edit</a></td>
-    </tr>
-    {% endfor %}
-  </table>
-  <h4>New Team</h4>
-  <form action="{{url_for('admin.new_team')}}" method="post">
-    <input type="text" placeholder="team_name" id="team_name" name="team_name" required>
-    <input type="submit">
-  </form>
-</body>
-</html>
+
+{% block content %}
+
+(This space left empty until someone bothers to fill it. See the links in the top-right)
+
+{% endblock %}

--- a/admin/templates/admin_main_layout.html
+++ b/admin/templates/admin_main_layout.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Google tag (gtag.js) -->
+    <!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-F4Y8SEJS54"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-F4Y8SEJS54');
+    </script>
+    <!-- End Google tag (gtag.js) -->
+
+    <!-- Reddit Pixel -->
+    <!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
+    <script>
+    !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','a2_h1gzo9j5z303');rdt('track', 'PageVisit');
+    </script>
+    <!-- End Reddit Pixel -->
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{url_for('static', filename='new-styles.css')}}">
+    <link href="https://cdn.jsdelivr.net/npm/hint.css@3.0.0/hint.min.css" rel="stylesheet">
+    <title>POPROX Newsletter</title>
+	{% block header %}
+	{% endblock %}
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <div class="navbar-brand">
+                <img class="logo" src="{{url_for('static', filename='POPROX24-temp00A-01.svg')}}" alt="logo">
+                <span>OPERATOR DASHBOARD</span>
+            </div>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="{{url_for('admin.team_manage')}}">Team Management</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{url_for('admin.account_search')}}">Account Management</a></li>
+                  </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container">
+        <div class="container py-3">
+            <div class="row">
+
+                <div class="col">
+
+                    {% if request.args.error %}
+                    <div class="error">{{request.args.error}}</div>
+                    {% endif %}
+                    {% block content %}
+                    {% endblock %}
+                </div>
+
+                <!-- <div class="col-md-1"></div> -->
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+</body>
+
+</html>

--- a/admin/templates/admin_team_management.html
+++ b/admin/templates/admin_team_management.html
@@ -1,0 +1,21 @@
+{% extends "admin_main_layout.html" %}
+
+
+
+{% block content %}
+  <h1>Team Management</h1>
+  <table>
+    <tr><th>Team Name</th><th>Actions</th></tr>
+    {% for team in teams.values() %}
+    <tr>
+        <td>{{team.team_name}}</td>
+        <td><a href="{{url_for('admin.team_details', team_id=team.team_id)}}">edit</a></td>
+    </tr>
+    {% endfor %}
+  </table>
+  <h4>New Team</h4>
+  <form action="{{url_for('admin.new_team')}}" method="post">
+    <input type="text" placeholder="team_name" id="team_name" name="team_name" required>
+    <input type="submit">
+  </form>
+  {% endblock %}


### PR DESCRIPTION
Flagging Karl since I don't know who else would be a good reviewer. Code is tested locally and seems to work just fine.

## Dependencies:

- CCRI-POPROX/poprox-storage#/134
- CCRI-POPROX/poprox-storage#/135
- CCRI-POPROX/poprox-concepts#62

## Features

- updated admin dashboard to use a jinja template based on the main one.
- moved team tools to their own page
- made an account lookup feature. Can look up in 2 ways:
    - by `account_id` directly
    - by email -- this supports `like` syntax (with `%`) since wildcard searches are sometimes very useful
- added account detail/edit page
    - views all fields of account model object
    - allows editing source, subsource, and email
    - reports errors when they occur.
    - reports if a status would flag an account as internal or external.