### PR TITLE
Make experiment dashboard button available in new layout pages.

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,12 @@ app.register_blueprint(exp)
 app.register_blueprint(static_web)
 
 
+@app.context_processor
+def dfault_jinja_variables():
+    """returned properties here will be added to all jinja renders"""
+    return dict(auth=auth)
+
+
 @app.route(f"{URL_PREFIX}/email_redirect/<path>")
 def email_redirect(path):
     data: LoginLinkData = from_hashed_base64(path, HMAC_KEY, LoginLinkData)
@@ -243,7 +249,7 @@ def consent1():
         # without agreeing to all sections
         missing = []
 
-    return render_template("consent1.html", error=error, missing=missing, auth=auth)
+    return render_template("consent1.html", error=error, missing=missing)
 
 
 @app.route(f"{URL_PREFIX}/consent2")
@@ -284,7 +290,6 @@ def home():
 
         return render_template(
             "home.html",
-            auth=auth,
             error=error,
             is_subscribed=is_subscribed,
         )
@@ -342,7 +347,6 @@ def feedback():
 
     return render_template(
         "feedback.html",
-        auth=auth,
         impressions=impressions,
         images=images,
     )
@@ -416,7 +420,6 @@ def topics():
         onboarding=onboarding,
         topics=GENERAL_TOPICS,
         intlvls=interest_lvls,
-        auth=auth,
         user_topic_preferences=user_topic_preferences,
     )
 
@@ -558,7 +561,6 @@ def onboarding_survey():
         clientopts=EMAIL_CLIENT_OPTIONS,
         giftcardopts=COMPENSATION_CARD_OPTIONS,
         donationopts=COMPENSATION_CHARITY_OPTIONS,
-        auth=auth,
         user_demographic_information=user_demographic_information,
     )
 

--- a/templates/new-layout.html
+++ b/templates/new-layout.html
@@ -68,9 +68,12 @@
                             </h6>
                             <div class="list-group">
                                 {% if auth.is_logged_in() %}
-                                <a href="{{ url_for('logout') }}" class="list-group-item list-group-item-action">Log Out</a>
-                                <a href="{{ url_for('topics') }}" class="list-group-item list-group-item-action">Topic Selection</a>
-                                <a href="{{ url_for('onboarding_survey') }}" class="list-group-item list-group-item-action">User Demographic</a>
+                                    <a href="{{ url_for('logout') }}" class="list-group-item list-group-item-action">Log Out</a>
+                                    <a href="{{ url_for('topics') }}" class="list-group-item list-group-item-action">Topic Selection</a>
+                                    <a href="{{ url_for('onboarding_survey') }}" class="list-group-item list-group-item-action">User Demographic</a>
+                                    {% if auth.get_account_teams()|length > 0%}
+                                        <a href="{{url_for('experimenter.expt_home')}}" class="list-group-item list-group-item-action">Experimenter Dashboard</a>
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
Also added a fancy bit of jinja syntax I just learned about which puts the `auth` variable in all jinja renders (which matches our use of this in parent templates)