### PR TITLE
added an eventListener to scroll accordion section to view

### DIFF
--- a/templates/consent1.html
+++ b/templates/consent1.html
@@ -40,7 +40,6 @@
 		} else {
 			if (header) {
 				header.classList.remove("checked");
-				// header.classList.add("error");
 			}
 			REQUIRED_CHECKBOXES[checkbox.id] = false;
 		}
@@ -73,14 +72,19 @@
 
 	window.addEventListener('DOMContentLoaded', function () {
 		submitButton = document.getElementById("submit-btn");
-		allCheckboxes = Array.from(document.querySelectorAll("input[type='checkbox']"));
 
-		allCheckboxes.forEach(checkbox => {
+		document.querySelectorAll("input[type='checkbox']").forEach(checkbox => {
 			if (REQUIRED_CHECKBOXES.hasOwnProperty(checkbox.id)) {
 				REQUIRED_CHECKBOXES[checkbox.id] = checkbox.checked;
 				checkbox.addEventListener('change', handleCheckboxChange);
 			}
 		});
+
+		document.querySelectorAll('.accordion-item').forEach(function (item) {
+			item.addEventListener('shown.bs.collapse', function () {
+				this.scrollIntoView({behavior: 'smooth', block: 'start'});
+			});
+		})
 
 		updateSubmitButtonState();
 	});


### PR DESCRIPTION
Three codes changes:

1. Removed a related commented code;
2. Removed a single use Array instantiation with anonymous function;
3. Added event listeners to each of the accordion headers, and bring the currently open section to focus.

Point 3 seems sufficiently different from what I had originally thought the solution was going to be. Bootstrap's accordion maintains an inner state for the entire accordion such that only one section is open at any given time. While that means that I couldn't use my original planned solution of opening next section without closing the previous one, we can safely assume that there is only one accordion section whose inner state is open at any given time. So, we scroll the open section to view.

Original behavior explained based on my testing: When we click on the checkbox, the event listener on the checkbox dispatched the event to change state of the next accordion to open. Since the dispatch is changing the class (the state) without any click event, the browser still hold focus on the clicked checkbox and tries to bring that view, resulting a race condition with the view becoming shorter. Causing the page to scroll past the active view box.