### PR TITLE
Add the correct compensation and risk text to the consent form 

### DIFF
--- a/templates/consent1.html
+++ b/templates/consent1.html
@@ -378,14 +378,15 @@
 				<section id="consent-section-4" class="consent-section accordion-collapse collapse"
 					data-bs-parent="#consent-form-accordion">
 					<div class="accordion-body">
-						<h3></h3>
 						<p>
-							The foreseeable risks involved in this study are minimal. They include possible discomfort in reading
-							uninterested or controversial news, minimum stress in answering survey questions, or potential concerns
-							about privacy associated with data logging. These risks can be mitigated by the fact that you can freely
-							choose to read whatever news you feel most interested in, your voluntary participation in surveys, and
-							your right to quit the survey at any time. Since participant data will be fully de-identified, the
-							privacy concern is also addressed. There may be risks which are currently unknown.
+						You will not receive any monetary compensation for your participation as a subscriber to
+						the POPROX newsletter.
+						</p>
+						<p>
+						Some individual studies may provide modest compensation for your time. We
+						may also provide modest compensation as a reward for participation and/or
+						longevity. We will ask you to select from compensation options that you can
+						change later when you are ready to get paid.
 						</p>
 						<div class="consent position-relative">
 							<b class="action">Check to continue:</b><br>
@@ -409,22 +410,13 @@
 				<section id="consent-section-5" class="consent-section accordion-collapse collapse"
 					data-bs-parent="#consent-form-accordion">
 					<div class="accordion-body">
-						<h3>6. Benefits</h3>
 						<p>
-							The potential benefits participants may gain include: 1) participants can get personalized daily news
-							recommendations and improve their news awareness; 2) participants can understand their news preferences
-							and consumption behaviors better.
-						</p>
-
-						<h3>7. Alternatives to Participation</h3>
-						<p>
-							This research study is for research purposes only. The only alternative is to not participate in this
-							study.
-						</p>
-
-						<h3>8. Costs</h3>
-						<p>
-							There will be no charge to you for your participation in this study.
+							The foreseeable risks involved in this study are minimal. They include possible discomfort in reading
+							uninterested or controversial news, minimum stress in answering survey questions, or potential concerns
+							about privacy associated with data logging. These risks can be mitigated by the fact that you can freely
+							choose to read whatever news you feel most interested in, your voluntary participation in surveys, and
+							your right to quit the survey at any time. Since participant data will be fully de-identified, the
+							privacy concern is also addressed. There may be risks which are currently unknown.
 						</p>
 
 						<div class="consent position-relative">

--- a/templates/consent1.html
+++ b/templates/consent1.html
@@ -435,7 +435,7 @@
 					<button class="accordion-button collapsed" type="button"
 						data-bs-toggle="collapse" data-bs-target="#consent-section-6" aria-expanded="false"
 						aria-control="consent-section-6">
-						<h2 class="text-black">Benefits, Alternatives to Participation, and Costs</h2>
+						<h2 class="text-black">6-8. Benefits, Alternatives to Participation, and Costs</h2>
 					</button>
 				</header>
 				<section id="consent-section-6" class="consent-section accordion-collapse collapse"


### PR DESCRIPTION
I think we just had an off-by-one error in which text was in which section, so I copied the compensation language from the PDF version and bumped things down so they match the accordion headers.