### PR TITLE
add guardrails for errors in unsubscribe

### DIFF
--- a/app.py
+++ b/app.py
@@ -290,6 +290,8 @@ def pre_unsubscribe():
                 You will be switched to the standard varient of newletters."
             # send survey -- todo
             return redirect(url_for("opt_out_of_experiments"))
+        else:
+            return render_template("pre_unsubscribe.html", error="Please choose an option below")
         conn.commit()
     return render_template(("post_unsubscribe.html"), error=error_description)
 

--- a/templates/pre_unsubscribe.html
+++ b/templates/pre_unsubscribe.html
@@ -55,6 +55,9 @@
         We're sorry to see you go!
     </h2>
     <br/>
+    {% if error is defined %}
+        <div class="alert alert-warning">{{error}}</div>
+    {% endif %}
     <div class="field">
         <label class="label">Choose an option:</label>
         <div class="control">
@@ -92,7 +95,7 @@
     </div>
 
     <div class="control">
-        <button class="button is-link" id="submit-button" type="submit">Unsubscribe</button>
+        <button class="button is-link" id="submit-button" type="submit" disabled>Unsubscribe</button>
     </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
This _should_ doublly prevent an error:

1. user clicks unsub link
2. User _ignores_ the drop-down tree for "what kind of unsub" and just clicks unsubsribe

Current behavior: 500 error. Expected behaviors:

- unsubscribe button shouldn't be enabled by default
- unrecognized unsubscribe should provide a message and put you back in the screen.