### PR TITLE
more csrf_tokens

### DIFF
--- a/admin/templates/admin_account_detail.html
+++ b/admin/templates/admin_account_detail.html
@@ -6,6 +6,8 @@
 
   <h1>Account Management</h1>
   <form method="post" action="{{url_for('admin.update_account_detail', account_id = account.account_id)}}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
     <dl>
     {% for key, value in account.model_dump().items() %}
       <dt>{{key}}</dt>

--- a/admin/templates/admin_edit_team.html
+++ b/admin/templates/admin_edit_team.html
@@ -8,6 +8,7 @@
   <h2>{{team.team_name}} ({{team.team_id}})</h2>
   <h3>Rename</h3>
   <form method="post" action = "{{url_for('admin.edit_team_name', team_id=team.team_id)}}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="text" id="team_name" name="team_name" placeholder="team_name" required>
     <input type="submit">
   </form>
@@ -20,6 +21,7 @@
 
   <h3>Add Member</h3>
   <form method="post" action="{{url_for('admin.add_to_team', team_id = team.team_id)}}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="email" id="email" name="email" placeholder="who">
     <input type="submit">
   </form>

--- a/admin/templates/admin_team_management.html
+++ b/admin/templates/admin_team_management.html
@@ -15,6 +15,7 @@
   </table>
   <h4>New Team</h4>
   <form action="{{url_for('admin.new_team')}}" method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="text" placeholder="team_name" id="team_name" name="team_name" required>
     <input type="submit">
   </form>

--- a/app.py
+++ b/app.py
@@ -418,10 +418,10 @@ def feedback():
 
         if feedbackType:
             newsletter_repo.store_newsletter_feedback(account_id, newsletter_id, feedbackType)
-            newsletter = newsletter_repo.fetch_newsletter(newsletter_id)
             conn.commit()
 
         # Fetch images for all impressions
+        newsletter = newsletter_repo.fetch_newsletter(newsletter_id)
         all_impressions = newsletter.impressions if newsletter else []
         images = fetch_images(image_repo, all_impressions)
 

--- a/experimenter/templates/team_dash_experiences.html
+++ b/experimenter/templates/team_dash_experiences.html
@@ -53,6 +53,7 @@
             <td>{{recommenders[experience.recommender_id]}}</td>
             <td>
               <form method="post" action="{{url_for('experimenter.team_experience_test_now', team_id = team.team_id, experience_id=experience.experience_id)}}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <input type="checkbox" required/>
                 <button type="submit" class="btn btn-warning btn-sm">TEST</button>
               </form>
@@ -106,6 +107,7 @@
             <td>{{recommenders[experience.recommender_id]}}</td>
             <td>
               <form method="post" action="{{url_for('experimenter.team_experience_test_now', team_id = team.team_id, experience_id=experience.experience_id)}}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <input type="checkbox" required/>
                 <button type="submit" class="btn btn-warning btn-sm">TEST</button>
               </form>

--- a/experimenter/templates/team_dash_members.html
+++ b/experimenter/templates/team_dash_members.html
@@ -24,6 +24,7 @@
 </ul>
 <h3>Add Member</h3>
 <form method="post" action="{{url_for('experimenter.add_to_team', team_id = team.team_id)}}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   <input type="email" id="email" name="email" placeholder="who">
   <input type="submit">
 </form>

--- a/experimenter/templates/team_dash_new_experience.html
+++ b/experimenter/templates/team_dash_new_experience.html
@@ -18,8 +18,9 @@
 <form class="row g-3" method="post" action="{{url_for('experimenter.team_edit_experience_post',team_id=team.team_id, experience_id=experience.experience_id)}}">
 {% else %}
 <form class="row g-3" method="post" action="{{url_for('experimenter.team_edit_experience_post',team_id=team.team_id)}}">
-
 {% endif %}
+
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   <div class="form-group col-4">
     <label for="name" class="form-label"> name </label>
     <input id="name" required name="name" type="text" class="form-control col-6" value="{{experience.name if experience else ''}}" placeholder="name">

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -9,8 +9,12 @@
 {% endblock %}
 
 {% block header %}
+<meta name="csrf-token" content="{{ csrf_token() }}">
+
 <script>
 	document.addEventListener("DOMContentLoaded", () => {
+		const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
 		document.querySelectorAll(".feedback-form").forEach(form => {
 			let clickedButton = null;
 
@@ -32,7 +36,8 @@
 				const response = await fetch(form.action, {
 					method: "POST",
 					headers: {
-						"Content-Type": "application/json"
+						"Content-Type": "application/json",
+						'X-CSRFToken': csrfToken
 					},
 					body: JSON.stringify(payload)
 				});
@@ -78,6 +83,7 @@
 	<div class="row" style="margin-top: 0.5em;">
 		<div class="col-2">
 			<form class="feedback-form feedback-class" action="{{ url_for('feedback') }}" method="POST">
+    			<input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 				<input type="hidden" id="newsletter_id" name="newsletter_id" value="{{ impression.newsletter_id }}">
 				<input type="hidden" id="impression_id" name="impression_id" value="{{ impression.impression_id }}">
 

--- a/templates/pre_unsubscribe.html
+++ b/templates/pre_unsubscribe.html
@@ -51,6 +51,7 @@
 {% endblock %}
 {% block content %}
 <form action="{{url_for('pre_unsubscribe')}}" method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <h2>
         We're sorry to see you go!
     </h2>
@@ -87,7 +88,7 @@
     </div>
 
     <div id="survey" class="field hidden" style="display:none;">
-        <p>By clicking the button below, we will remove you from the current newsletter variant. 
+        <p>By clicking the button below, we will remove you from the current newsletter variant.
             You will be receiving the standard POPROX newsletter until you are assigned to the next experiment. <br>
             We will send you a survey asking you why you want to return to the standard newsletter. <br>
         </p>


### PR DESCRIPTION
To be clear -- my plan here is to self-review for "this could cause harm" and then immediately deploy since prod is broken.

We _know_ the un-subscribe workflow is broken. I suspect the article feedback page is broken. I suspect the admin pages are a bit broken too.  

What I did to try to hit 00% coverage: 1) searched for any usage of fetch, 2) searched for any html form 3) ignored examples that are only GET method.

- [x] manual code review
- [x] test locally:
    - create account
    - delete account
    - feedback
- [ ] merge

If I get a review while I'm working -- great. if I don't. I'll take a post-hoc review.