### PR TITLE
Remove feedback icons from the version of the newsletter we put in NLS survey

### DIFF
--- a/app.py
+++ b/app.py
@@ -429,6 +429,7 @@ def feedback():
         "feedback.html",
         newsletter=newsletter,
         images=images,
+        nls_survey=request.args.get("nls_survey"),
     )
 
 

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -82,6 +82,7 @@
 	{% for impression in section.impressions %}
 	<div class="row" style="margin-top: 0.5em;">
 		<div class="col-2">
+			{% if not nls_survey %}
 			<form class="feedback-form feedback-class" action="{{ url_for('feedback') }}" method="POST">
     			<input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 				<input type="hidden" id="newsletter_id" name="newsletter_id" value="{{ impression.newsletter_id }}">
@@ -99,6 +100,7 @@
 					👎
 				</button>
 			</form>
+			{% endif %}
 		</div>
 		<div class="col-2">
 			{% if impression.preview_image_id and impression.preview_image_id in images %}


### PR DESCRIPTION
I have added a query parameter to the feedback route that hides the 👍/👎 buttons when rendering the newsletter. 

Is this the right approach, or is there an existing mechanism for the NLS survey embed I should be using instead?

Also, I want to make sure the query param name matches what's already been set up.