### PR TITLE
Sample Newsletter - Create newsletter_preview Page

### DIFF
--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -16,11 +16,11 @@ from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
 
 try:
-    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+    from poprox_platform.newsletter.preview import newsletter_preview_context
 except ModuleNotFoundError:
     platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
     sys.path.insert(0, str(platform_root))
-    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+    from poprox_platform.newsletter.preview import newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")
@@ -90,7 +90,8 @@ def newsletter_loader_post():
 
 @dev.route("/newsletter_preview")
 def newsletter_preview():
-    newsletter_id = request.args.get("newsletter_id", str(DEFAULT_PREVIEW_NEWSLETTER_ID))
+    newsletter_id = request.args.get("newsletter_id")
+    account_id = request.args.get("account_id")
     disable_links = request.args.get("disable_links", "false").lower() == "true"
     remove_footer = request.args.get("remove_footer", "false").lower() == "true"
 
@@ -100,11 +101,12 @@ def newsletter_preview():
             context = newsletter_preview_context(
                 newsletter_repo,
                 newsletter_id,
+                account_id,
                 disable_links=disable_links,
                 remove_footer=remove_footer,
             )
         except ValueError:
-            return "Invalid newsletter_id", 400
+            return "Invalid newsletter_id or account_id", 400
 
     if context is None:
         return "Newsletter not found", 404

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import hmac
-import sys
 from os import environ as env
 from pathlib import Path
 
@@ -14,13 +13,7 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 from poprox_concepts.api.tracking import LoginLinkData, TrackingLinkData
 from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
-
-try:
-    from poprox_platform.newsletter.preview import newsletter_preview_context
-except ModuleNotFoundError:
-    platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
-    sys.path.insert(0, str(platform_root))
-    from poprox_platform.newsletter.preview import newsletter_preview_context
+from util.newsletter_preview import newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -93,7 +93,7 @@ def newsletter_preview():
     newsletter_id = request.args.get("newsletter_id")
     account_id = request.args.get("account_id")
     disable_links = request.args.get("disable_links", "false").lower() == "true"
-    remove_footer = request.args.get("remove_footer", "false").lower() == "true"
+    remove_footer = request.args.get("remove_footer", "true").lower() != "false"
 
     with DB_ENGINE.connect() as conn:
         newsletter_repo = DbNewsletterRepository(conn)

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import sys
 from os import environ as env
 from pathlib import Path
 
@@ -13,6 +14,13 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 from poprox_concepts.api.tracking import LoginLinkData, TrackingLinkData
 from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
+
+try:
+    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+except ModuleNotFoundError:
+    platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
+    sys.path.insert(0, str(platform_root))
+    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")
@@ -78,6 +86,30 @@ def newsletter_loader_post():
     return render_template(
         "newsletter_loader_post.html", url=url_for("feedback", newsletter_id=the_newsletter.newsletter_id)
     )
+
+
+@dev.route("/newsletter_preview")
+def newsletter_preview():
+    newsletter_id = request.args.get("newsletter_id", str(DEFAULT_PREVIEW_NEWSLETTER_ID))
+    disable_links = request.args.get("disable_links", "false").lower() == "true"
+    remove_footer = request.args.get("remove_footer", "false").lower() == "true"
+
+    with DB_ENGINE.connect() as conn:
+        newsletter_repo = DbNewsletterRepository(conn)
+        try:
+            context = newsletter_preview_context(
+                newsletter_repo,
+                newsletter_id,
+                disable_links=disable_links,
+                remove_footer=remove_footer,
+            )
+        except ValueError:
+            return "Invalid newsletter_id", 400
+
+    if context is None:
+        return "Newsletter not found", 404
+
+    return render_template("newsletter_preview.html", **context)
 
 
 @dev.route("/decode")

--- a/templates/newsletter_preview.html
+++ b/templates/newsletter_preview.html
@@ -1,0 +1,1 @@
+{{ newsletter_html|safe }}

--- a/util/newsletter_preview.py
+++ b/util/newsletter_preview.py
@@ -1,0 +1,57 @@
+import logging
+from uuid import UUID
+
+from bs4 import BeautifulSoup
+from poprox_storage.repositories.newsletters import DbNewsletterRepository
+
+logger = logging.getLogger(__name__)
+
+
+def process_html(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
+    soup = BeautifulSoup(body or "", "html.parser")
+    remove_newsletter_footers(soup)
+
+    if remove_footer:
+        for div in soup.find_all("div", class_="footer"):
+            div.decompose()
+
+    if disable_links:
+        for link in soup.find_all("a"):
+            if "href" in link.attrs:
+                del link.attrs["href"]
+                link.attrs["title"] = "This is a preview. Links are disabled."
+    else:
+        for link in soup.find_all("a"):
+            if "href" in link.attrs:
+                link.attrs["target"] = "_blank"
+                link.attrs["rel"] = "noopener noreferrer"
+
+    return str(soup)
+
+
+def remove_newsletter_footers(soup):
+    for link in soup.find_all("a", class_="learn_more"):
+        link.decompose()
+
+    for feedback_block in soup.find_all("div", class_="newsletter_feedback"):
+        feedback_block.decompose()
+
+
+def newsletter_preview_context(
+    newsletter_repo: DbNewsletterRepository,
+    newsletter_id: str | UUID | None = None,
+    account_id: str | UUID | None = None,
+    *,
+    disable_links: bool = False,
+    remove_footer: bool = True,
+) -> dict | None:
+    parsed_newsletter_id = UUID(str(newsletter_id)) if newsletter_id else None
+    parsed_account_id = UUID(str(account_id)) if account_id else None
+    body_html = newsletter_repo.fetch_newsletter_preview(parsed_newsletter_id, parsed_account_id)
+
+    if body_html is None:
+        return None
+
+    return {
+        "newsletter_html": process_html(body_html, disable_links=disable_links, remove_footer=remove_footer),
+    }

--- a/util/newsletter_preview.py
+++ b/util/newsletter_preview.py
@@ -7,7 +7,7 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 logger = logging.getLogger(__name__)
 
 
-def process_html(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
+def remove_newsletter_feedback(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
     soup = BeautifulSoup(body or "", "html.parser")
     remove_newsletter_footers(soup)
 
@@ -53,5 +53,7 @@ def newsletter_preview_context(
         return None
 
     return {
-        "newsletter_html": process_html(body_html, disable_links=disable_links, remove_footer=remove_footer),
+        "newsletter_html": remove_newsletter_feedback(
+            body_html, disable_links=disable_links, remove_footer=remove_footer
+        ),
     }


### PR DESCRIPTION
First trial to create a new `newsletter_preview` template from scratch based on an newsletter html object stored in DB. Links on the newsletter are enabled. Some design questions / decisions left:

- [x] Shall we remove the `Learn More` button and footers? Currently they lead to the test user's account management page. 

<img width="950" height="897" alt="Screenshot 2026-04-22 at 8 28 07 PM" src="https://github.com/user-attachments/assets/b8830852-8d2c-439e-ba23-b74d82e82535" />
<img width="986" height="930" alt="Screenshot 2026-04-22 at 8 28 18 PM" src="https://github.com/user-attachments/assets/880a883a-462a-43be-8140-4a301c300aac" />

After creating this template, the next step for us is to integrate the interactive sample newsletter to the `enroll` page to replace the static example newsletter image.

