### PR TITLE
Integrate sample newsletter into enroll page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
 # ruff: noqa: E402
 
 import logging
+import sys
 from datetime import datetime, timezone
 from os import environ as env
+from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
 from flask import Flask, jsonify, redirect, render_template, request, url_for
@@ -184,6 +186,43 @@ def pre_enroll_get():
         template = templates[(source, subsource)]
 
     return render_template(template, source=source, subsource=subsource, error=error)
+
+
+def get_newsletter_preview_context():
+    try:
+        from poprox_platform.newsletter.preview import newsletter_preview_context
+    except ModuleNotFoundError:
+        platform_root = Path(__file__).resolve().parents[1] / "poprox-platform"
+        sys.path.insert(0, str(platform_root))
+        from poprox_platform.newsletter.preview import newsletter_preview_context
+
+    newsletter_id = request.args.get("newsletter_id")
+    account_id = request.args.get("account_id")
+    disable_links = request.args.get("disable_links", "false").lower() == "true"
+    remove_footer = request.args.get("remove_footer", "true").lower() != "false"
+
+    with DB_ENGINE.connect() as conn:
+        newsletter_repo = DbNewsletterRepository(conn)
+        return newsletter_preview_context(
+            newsletter_repo,
+            newsletter_id,
+            account_id,
+            disable_links=disable_links,
+            remove_footer=remove_footer,
+        )
+
+
+@app.route(f"{URL_PREFIX}/newsletter_preview")
+def newsletter_preview():
+    try:
+        context = get_newsletter_preview_context()
+    except ValueError:
+        return "Invalid newsletter_id or account_id", 400
+
+    if context is None:
+        return "Newsletter not found", 404
+
+    return render_template("newsletter_preview.html", **context)
 
 
 @app.route(f"{URL_PREFIX}/subscribe", methods=["POST"])

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -34,7 +34,12 @@
 
 <div class="row">
 	<div class="card-body col-md-6 col-lg-5">
-		<img class="image-fluid mx-auto d-block" src="static/example-newsletter.jpg" width="80%" style="max-width:400px;max-height:600px;">
+		<iframe
+			class="mx-auto d-block"
+			src="{{ url_for('newsletter_preview') }}"
+			title="Example POPROX newsletter"
+			style="width: 100%; max-width: 420px; height: 620px; border: 1px solid #bdbdc5; border-radius: 4px; background: #f8f8ff;"
+		></iframe>
 	</div>
 	<div class="card-body col-md-6 col-lg-5 pt-lg-5">
 		<h5 class="card-title">What's POPROX News?</h5>


### PR DESCRIPTION
### Step 2 for sample newsletter task. 
Based on the newsletter_preview module introduced in https://github.com/CCRI-POPROX/poprox-web/pull/140 and https://github.com/CCRI-POPROX/poprox-platform/pull/791, we replace the static example newsletter image on POPROX signup page with the interactive sample newsletter component.
<img width="1185" height="888" alt="Screenshot 2026-04-22 at 8 37 19 PM" src="https://github.com/user-attachments/assets/81986f06-6641-48b6-ac6e-07a590f32afa" />
