### PR TITLE
Sristy/feature/sample newsletter tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@
 import logging
 from datetime import datetime, timezone
 from os import environ as env
+from pathlib import Path
+import sys
 
 from dotenv import find_dotenv, load_dotenv
 from flask import Flask, jsonify, redirect, render_template, request, url_for
@@ -12,6 +14,7 @@ ENV_FILE = find_dotenv()
 if ENV_FILE:
     load_dotenv(ENV_FILE)
 
+from poprox_storage.aws import DB_ENGINE as NEWSLETTER_PREVIEW_DB_ENGINE
 from poprox_storage.aws.queues import enqueue_newsletter_request
 from poprox_storage.repositories.account_interest_log import DbAccountInterestRepository
 from poprox_storage.repositories.accounts import DbAccountRepository
@@ -52,6 +55,13 @@ from util.postgres_db import (
     finish_topic_selection,
     get_token,
 )
+
+try:
+    from poprox_platform.newsletter.preview import newsletter_preview_context # type: ignore
+except ModuleNotFoundError:
+    platform_root = Path(__file__).resolve().parents[1] / "poprox-platform"
+    sys.path.insert(0, str(platform_root))
+    from poprox_platform.newsletter.preview import newsletter_preview_context # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -176,14 +186,37 @@ def pre_enroll_get():
     source = request.args.get("source", DEFAULT_SOURCE)
     subsource = request.args.get("subsource", DEFAULT_SOURCE)
     error = request.args.get("error")
+    sample_newsletter_id = request.args.get("newsletter_id")
+    sample_account_id = request.args.get("account_id")
+    sample_newsletter_html = None
+    with NEWSLETTER_PREVIEW_DB_ENGINE.connect() as conn:
+        newsletter_repo = DbNewsletterRepository(conn)
+        try:
+            preview_context = newsletter_preview_context(
+                newsletter_repo,
+                sample_newsletter_id,
+                sample_account_id,
+                disable_links=True,
+                remove_footer=True,
+            )
+        except ValueError:
+            preview_context = None
 
-    # To test a source, subsource pair with a custom template just add that to this dictionary
+    if preview_context:
+        sample_newsletter_html = preview_context["newsletter_html"]
+
     templates = {}
     template = "pre_enroll.html"
     if (source, subsource) in templates:
         template = templates[(source, subsource)]
 
-    return render_template(template, source=source, subsource=subsource, error=error)
+    return render_template(
+        template,
+        source=source,
+        subsource=subsource,
+        error=error,
+        sample_newsletter_html=sample_newsletter_html,
+    )
 
 
 @app.route(f"{URL_PREFIX}/subscribe", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@
 import logging
 from datetime import datetime, timezone
 from os import environ as env
-from pathlib import Path
-import sys
 
 from dotenv import find_dotenv, load_dotenv
 from flask import Flask, jsonify, redirect, render_template, request, url_for
@@ -55,13 +53,7 @@ from util.postgres_db import (
     finish_topic_selection,
     get_token,
 )
-
-try:
-    from poprox_platform.newsletter.preview import newsletter_preview_context # type: ignore
-except ModuleNotFoundError:
-    platform_root = Path(__file__).resolve().parents[1] / "poprox-platform"
-    sys.path.insert(0, str(platform_root))
-    from poprox_platform.newsletter.preview import newsletter_preview_context # type: ignore
+from util.newsletter_preview import newsletter_preview_context
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +61,8 @@ COMPENSATION_OPTIONS = COMPENSATION_CARD_OPTIONS + COMPENSATION_CHARITY_OPTIONS 
 
 DEFAULT_RECS_ENDPOINT_URL = env.get("POPROX_DEFAULT_RECS_ENDPOINT_URL")
 DEFAULT_SOURCE = "website"
+SAMPLE_NEWSLETTER_ID = env.get("POPROX_SAMPLE_NEWSLETTER_ID")
+SAMPLE_NEWSLETTER_ACCOUNT_ID = env.get("POPROX_SAMPLE_NEWSLETTER_ACCOUNT_ID")
 URL_PREFIX = env.get("URL_PREFIX", "/")
 
 app = Flask(__name__)
@@ -186,16 +180,14 @@ def pre_enroll_get():
     source = request.args.get("source", DEFAULT_SOURCE)
     subsource = request.args.get("subsource", DEFAULT_SOURCE)
     error = request.args.get("error")
-    sample_newsletter_id = request.args.get("newsletter_id")
-    sample_account_id = request.args.get("account_id")
     sample_newsletter_html = None
     with NEWSLETTER_PREVIEW_DB_ENGINE.connect() as conn:
         newsletter_repo = DbNewsletterRepository(conn)
         try:
             preview_context = newsletter_preview_context(
                 newsletter_repo,
-                sample_newsletter_id,
-                sample_account_id,
+                SAMPLE_NEWSLETTER_ID,
+                SAMPLE_NEWSLETTER_ACCOUNT_ID,
                 disable_links=True,
                 remove_footer=True,
             )

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -16,11 +16,11 @@ from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
 
 try:
-    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+    from poprox_platform.newsletter.preview import newsletter_preview_context
 except ModuleNotFoundError:
     platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
     sys.path.insert(0, str(platform_root))
-    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+    from poprox_platform.newsletter.preview import newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")
@@ -90,7 +90,8 @@ def newsletter_loader_post():
 
 @dev.route("/newsletter_preview")
 def newsletter_preview():
-    newsletter_id = request.args.get("newsletter_id", str(DEFAULT_PREVIEW_NEWSLETTER_ID))
+    newsletter_id = request.args.get("newsletter_id")
+    account_id = request.args.get("account_id")
     disable_links = request.args.get("disable_links", "false").lower() == "true"
     remove_footer = request.args.get("remove_footer", "false").lower() == "true"
 
@@ -100,11 +101,12 @@ def newsletter_preview():
             context = newsletter_preview_context(
                 newsletter_repo,
                 newsletter_id,
+                account_id,
                 disable_links=disable_links,
                 remove_footer=remove_footer,
             )
         except ValueError:
-            return "Invalid newsletter_id", 400
+            return "Invalid newsletter_id or account_id", 400
 
     if context is None:
         return "Newsletter not found", 404

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import hmac
-import sys
 from os import environ as env
 from pathlib import Path
 
@@ -14,13 +13,7 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 from poprox_concepts.api.tracking import LoginLinkData, TrackingLinkData
 from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
-
-try:
-    from poprox_platform.newsletter.preview import newsletter_preview_context
-except ModuleNotFoundError:
-    platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
-    sys.path.insert(0, str(platform_root))
-    from poprox_platform.newsletter.preview import newsletter_preview_context
+from util.newsletter_preview import newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -93,7 +93,7 @@ def newsletter_preview():
     newsletter_id = request.args.get("newsletter_id")
     account_id = request.args.get("account_id")
     disable_links = request.args.get("disable_links", "false").lower() == "true"
-    remove_footer = request.args.get("remove_footer", "false").lower() == "true"
+    remove_footer = request.args.get("remove_footer", "true").lower() != "false"
 
     with DB_ENGINE.connect() as conn:
         newsletter_repo = DbNewsletterRepository(conn)

--- a/dev/dev_blueprint.py
+++ b/dev/dev_blueprint.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import sys
 from os import environ as env
 from pathlib import Path
 
@@ -13,6 +14,13 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 from poprox_concepts.api.tracking import LoginLinkData, TrackingLinkData
 from poprox_concepts.domain.newsletter import Newsletter
 from util.auth import auth
+
+try:
+    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
+except ModuleNotFoundError:
+    platform_root = Path(__file__).resolve().parents[2] / "poprox-platform"
+    sys.path.insert(0, str(platform_root))
+    from poprox_platform.newsletter.preview import DEFAULT_PREVIEW_NEWSLETTER_ID, newsletter_preview_context
 
 dev = Blueprint("dev", __name__, template_folder="templates", url_prefix="/dev")
 HMAC_KEY = env.get("POPROX_HMAC_KEY", "defaultpoproxhmackey")
@@ -78,6 +86,30 @@ def newsletter_loader_post():
     return render_template(
         "newsletter_loader_post.html", url=url_for("feedback", newsletter_id=the_newsletter.newsletter_id)
     )
+
+
+@dev.route("/newsletter_preview")
+def newsletter_preview():
+    newsletter_id = request.args.get("newsletter_id", str(DEFAULT_PREVIEW_NEWSLETTER_ID))
+    disable_links = request.args.get("disable_links", "false").lower() == "true"
+    remove_footer = request.args.get("remove_footer", "false").lower() == "true"
+
+    with DB_ENGINE.connect() as conn:
+        newsletter_repo = DbNewsletterRepository(conn)
+        try:
+            context = newsletter_preview_context(
+                newsletter_repo,
+                newsletter_id,
+                disable_links=disable_links,
+                remove_footer=remove_footer,
+            )
+        except ValueError:
+            return "Invalid newsletter_id", 400
+
+    if context is None:
+        return "Newsletter not found", 404
+
+    return render_template("newsletter_preview.html", **context)
 
 
 @dev.route("/decode")

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -33,7 +33,7 @@ body {
     letter-spacing: 1px;
 }
 
-.navbar .logo {
+.navbar .site-logo {
     max-height: 70px;
 }
 
@@ -45,6 +45,155 @@ body {
 .nav-link:hover {
     color: rgb(46, 128, 119) !important;
     text-decoration: none;
+}
+
+.preview-card-body {
+    display: flex;
+    justify-content: center;
+}
+
+.sample-newsletter-shell {
+    border: 1px solid #212A37;
+    box-sizing: border-box;
+    width: 100%;
+}
+
+.sample-newsletter-tabs {
+    align-items: stretch;
+    border-bottom: 1px solid #212A37;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.sample-newsletter-tab {
+    background-color: #f8f8ff;
+    border: 0;
+    border-right: 1px solid #212A37;
+    color: #000;
+    cursor: pointer;
+    font-size: 0.8rem;
+    line-height: 1.1;
+    min-height: 46px;
+    padding: 2% 1.5%;
+    text-align: left;
+    text-decoration: none;
+    transition: background-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.sample-newsletter-tab:last-child {
+    border-right: 0;
+}
+
+.sample-newsletter-tab.active {
+    background-color: #fff;
+    box-shadow: inset 0 -3px 0 #008f83;
+    font-weight: 600;
+}
+
+.sample-newsletter-tab-link {
+    background-color: #fff7d6;
+    display: block;
+}
+
+.sample-newsletter-tab:hover,
+.sample-newsletter-tab:focus-visible {
+    background-color: #e9f6f4;
+    outline: none;
+}
+
+.sample-newsletter-tab:active {
+    transform: translateY(1px);
+}
+
+.sample-newsletter-tab-link:hover,
+.sample-newsletter-tab-link:focus-visible {
+    background-color: #ffe8a3;
+    color: #000;
+}
+
+.sample-newsletter-preview {
+    background-color: #f8f8ff;
+    border: 0;
+    box-sizing: border-box;
+    font-size: 0.7rem;
+    width: 100%;
+}
+
+.sample-newsletter-panel {
+    display: none;
+    margin-left: auto;
+    margin-right: auto;
+    max-height: 410px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    width: 72%;
+}
+
+.sample-newsletter-panel.active {
+    display: block;
+}
+
+.sample-newsletter-panel.tab-changed {
+    animation: sample-preview-tab-change 180ms ease;
+}
+
+@keyframes sample-preview-tab-change {
+    0% {
+        opacity: 0.72;
+        transform: translateY(2px);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.sample-newsletter-preview .body-content,
+.sample-newsletter-preview .logo,
+.sample-newsletter-preview .section_title {
+    box-sizing: border-box;
+    margin-bottom: 0 !important;
+    max-width: 100% !important;
+    width: 100% !important;
+}
+
+.sample-newsletter-preview * {
+    max-width: 100%;
+}
+
+.sample-newsletter-preview .article {
+    box-sizing: border-box;
+    max-width: 100% !important;
+    width: auto !important;
+}
+
+.sample-newsletter-preview .article:last-of-type,
+.sample-newsletter-preview .divider:last-of-type,
+.sample-newsletter-preview .body-content > :last-child {
+    margin-bottom: 0 !important;
+}
+
+.sample-newsletter-preview div.article .label,
+.sample-newsletter-preview div.article .subhead,
+.sample-newsletter-preview div.article .content {
+    font-size: 0.65rem !important;
+}
+
+.sample-newsletter-preview div.article .headline {
+    font-size: 0.75rem !important;
+    line-height: 1.25 !important;
+}
+
+.sample-newsletter-preview h2.section_title table,
+.sample-newsletter-preview .section_title table {
+    font-size: 0.85rem !important;
+    margin-left: 5%;
+}
+
+.sample-newsletter-preview img,
+.sample-newsletter-preview table {
+    max-width: 100% !important;
 }
 
 .nav-tabs .nav-link {
@@ -74,6 +223,10 @@ footer {
     flex-grow: 0;
 }
 
+.row{
+    padding-top: 2%;
+}
+
 
 /* Cards */
 .card {
@@ -83,9 +236,12 @@ footer {
     color: #212A37;
     box-shadow: 0 6px 12px #a3abbd99;
     padding: 15px;
-    /* text-align: center; */
     transition: all 0.3s ease-in-out;
     margin-bottom: 20px;
+}
+
+.card-title {
+    padding-bottom: 5px;
 }
 
 .card-body {

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -123,7 +123,7 @@ body {
     display: none;
     margin-left: auto;
     margin-right: auto;
-    max-height: 410px;
+    max-height: 500px;
     overflow-x: hidden;
     overflow-y: auto;
     width: 72%;
@@ -235,17 +235,12 @@ footer {
     background-color: #a3abbd22;
     color: #212A37;
     box-shadow: 0 6px 12px #a3abbd99;
-    padding: 15px;
     transition: all 0.3s ease-in-out;
     margin-bottom: 20px;
 }
 
 .card-title {
     padding-bottom: 5px;
-}
-
-.card-body {
-    padding: 10px;
 }
 
 /* Buttons */

--- a/static/new-styles.css
+++ b/static/new-styles.css
@@ -116,16 +116,20 @@ body {
     border: 0;
     box-sizing: border-box;
     font-size: 0.7rem;
+    height: 760px;
+    overflow-x: hidden;
+    overflow-y: hidden;
     width: 100%;
 }
 
 .sample-newsletter-panel {
     display: none;
+    height: 100%;
     margin-left: auto;
     margin-right: auto;
-    max-height: 500px;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-gutter: stable;
     width: 72%;
 }
 
@@ -194,6 +198,21 @@ body {
 .sample-newsletter-preview img,
 .sample-newsletter-preview table {
     max-width: 100% !important;
+}
+
+.sample-newsletter-preview img {
+    height: auto !important;
+}
+
+@media (max-width: 767px) {
+    .sample-newsletter-preview {
+        height: 70vh;
+        min-height: 480px;
+    }
+
+    .sample-newsletter-panel {
+        width: 100%;
+    }
 }
 
 .nav-tabs .nav-link {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -35,7 +35,7 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
-            <img class="logo" src="{{url_for('static', filename='POPROX24-temp00A-01.svg')}}" alt="logo">
+            <img class="site-logo" src="{{url_for('static', filename='POPROX24-temp00A-01.svg')}}" alt="logo">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/templates/newsletter_preview.html
+++ b/templates/newsletter_preview.html
@@ -1,0 +1,1 @@
+{{ newsletter_html|safe }}

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -32,11 +32,39 @@
 	<h5 class="card-title text-center">There's so much more happening in the world. We can help you discover it!</h5>
 </div>
 
-<div class="row">
-	<div class="card-body col-md-6 col-lg-5">
-		<img class="image-fluid mx-auto d-block" src="static/example-newsletter.jpg" width="80%" style="max-width:400px;max-height:600px;">
+<div class="row gx-lg-5">
+	<div class="preview-card-body col-md-7 col-lg-7">
+		{% set sample_newsletter_profiles = [
+			("popular", "Example Profile 1", "(Popular topics)"),
+			("sports", "Example Profile 2", "(Sports / entertainment)"),
+			("science", "Example Profile 3", "(Science and oddities)")
+		] %}
+		<div class="sample-newsletter-shell">
+			<div class="sample-newsletter-tabs" role="tablist" aria-label="Example newsletter profiles">
+				{% for profile_id, profile_name, profile_description in sample_newsletter_profiles %}
+				<button class="sample-newsletter-tab 
+				{% if loop.first %}active{% endif %}" type="button" role="tab" 
+				aria-selected="{{ 'true' if loop.first else 'false' }}" 
+				data-sample-newsletter-tab="{{ profile_id }}">{{ profile_name }}<br>{{ profile_description }}</button>
+				{% endfor %}
+				<a class="sample-newsletter-tab sample-newsletter-tab-link" href="#email">Create your own!</a>
+			</div>
+			{% if sample_newsletter_html %}
+			<div class="sample-newsletter-preview mx-auto d-block">
+				{% for profile_id, profile_name, profile_description in sample_newsletter_profiles %}
+				<div class="sample-newsletter-panel 
+				{% if loop.first %}active{% endif %}" 
+				data-sample-newsletter-panel="{{ profile_id }}">
+					{{ sample_newsletter_html|safe }}
+				</div>
+				{% endfor %}
+			</div>
+			{% else %}
+			<img class="sample-newsletter-preview mx-auto d-block" src="static/example-newsletter.jpg">
+			{% endif %}
+		</div>
 	</div>
-	<div class="card-body col-md-6 col-lg-5 pt-lg-5">
+	<div class="card-body col-md-5 col-lg-5">
 		<h5 class="card-title">What's POPROX News?</h5>
 		<p class="card-text">POPROX is an ad-free daily news briefing curated just for you based on the topics you like and the articles you read. We’re an independent, non-commercial research project and your subscription helps us improve news recommendation technology.</p>
 		<h5 class="card-title">Ready to get started?</h5>
@@ -77,5 +105,30 @@
 		in Research Agreement</a>.
 	</p>
 </div>
+
+<script>
+	const sampleNewsletterTabs = document.querySelectorAll("[data-sample-newsletter-tab]");
+	const sampleNewsletterPanels = document.querySelectorAll("[data-sample-newsletter-panel]");
+	sampleNewsletterTabs.forEach((tab) => {
+		tab.addEventListener("click", () => {
+			const selectedProfile = tab.dataset.sampleNewsletterTab;
+			sampleNewsletterTabs.forEach((inactiveTab) => {
+				inactiveTab.classList.remove("active");
+				inactiveTab.setAttribute("aria-selected", "false");
+			});
+			sampleNewsletterPanels.forEach((panel) => {
+				const isSelectedPanel = panel.dataset.sampleNewsletterPanel === selectedProfile;
+				panel.classList.toggle("active", isSelectedPanel);
+				panel.classList.remove("tab-changed");
+				if (isSelectedPanel) {
+					void panel.offsetWidth;
+					panel.classList.add("tab-changed");
+				}
+			});
+			tab.classList.add("active");
+			tab.setAttribute("aria-selected", "true");
+		});
+	});
+</script>
 
 {% endblock %}

--- a/templates/pre_enroll.html
+++ b/templates/pre_enroll.html
@@ -32,7 +32,7 @@
 	<h5 class="card-title text-center">There's so much more happening in the world. We can help you discover it!</h5>
 </div>
 
-<div class="row gx-lg-5">
+<div class="row gx-lg-5 align-items-center">
 	<div class="preview-card-body col-md-7 col-lg-7">
 		{% set sample_newsletter_profiles = [
 			("popular", "Example Profile 1", "(Popular topics)"),
@@ -64,7 +64,7 @@
 			{% endif %}
 		</div>
 	</div>
-	<div class="card-body col-md-5 col-lg-5">
+	<div class="card-body col-md-5 col-lg-5 ps-lg-4">
 		<h5 class="card-title">What's POPROX News?</h5>
 		<p class="card-text">POPROX is an ad-free daily news briefing curated just for you based on the topics you like and the articles you read. We’re an independent, non-commercial research project and your subscription helps us improve news recommendation technology.</p>
 		<h5 class="card-title">Ready to get started?</h5>

--- a/util/newsletter_preview.py
+++ b/util/newsletter_preview.py
@@ -1,0 +1,57 @@
+import logging
+from uuid import UUID
+
+from bs4 import BeautifulSoup
+from poprox_storage.repositories.newsletters import DbNewsletterRepository
+
+logger = logging.getLogger(__name__)
+
+
+def process_html(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
+    soup = BeautifulSoup(body or "", "html.parser")
+    remove_newsletter_footers(soup)
+
+    if remove_footer:
+        for div in soup.find_all("div", class_="footer"):
+            div.decompose()
+
+    if disable_links:
+        for link in soup.find_all("a"):
+            if "href" in link.attrs:
+                del link.attrs["href"]
+                link.attrs["title"] = "This is a preview. Links are disabled."
+    else:
+        for link in soup.find_all("a"):
+            if "href" in link.attrs:
+                link.attrs["target"] = "_blank"
+                link.attrs["rel"] = "noopener noreferrer"
+
+    return str(soup)
+
+
+def remove_newsletter_footers(soup):
+    for link in soup.find_all("a", class_="learn_more"):
+        link.decompose()
+
+    for feedback_block in soup.find_all("div", class_="newsletter_feedback"):
+        feedback_block.decompose()
+
+
+def newsletter_preview_context(
+    newsletter_repo: DbNewsletterRepository,
+    newsletter_id: str | UUID | None = None,
+    account_id: str | UUID | None = None,
+    *,
+    disable_links: bool = False,
+    remove_footer: bool = True,
+) -> dict | None:
+    parsed_newsletter_id = UUID(str(newsletter_id)) if newsletter_id else None
+    parsed_account_id = UUID(str(account_id)) if account_id else None
+    body_html = newsletter_repo.fetch_newsletter_preview(parsed_newsletter_id, parsed_account_id)
+
+    if body_html is None:
+        return None
+
+    return {
+        "newsletter_html": process_html(body_html, disable_links=disable_links, remove_footer=remove_footer),
+    }

--- a/util/newsletter_preview.py
+++ b/util/newsletter_preview.py
@@ -7,7 +7,7 @@ from poprox_storage.repositories.newsletters import DbNewsletterRepository
 logger = logging.getLogger(__name__)
 
 
-def process_html(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
+def remove_newsletter_feedback(body: str, *, disable_links: bool = False, remove_footer: bool = True) -> str:
     soup = BeautifulSoup(body or "", "html.parser")
     remove_newsletter_footers(soup)
 
@@ -53,5 +53,7 @@ def newsletter_preview_context(
         return None
 
     return {
-        "newsletter_html": process_html(body_html, disable_links=disable_links, remove_footer=remove_footer),
+        "newsletter_html": remove_newsletter_feedback(
+            body_html, disable_links=disable_links, remove_footer=remove_footer
+        ),
     }

--- a/util/newsletter_preview.py
+++ b/util/newsletter_preview.py
@@ -1,7 +1,9 @@
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 
 from bs4 import BeautifulSoup
+from sqlalchemy import and_, select
 from poprox_storage.repositories.newsletters import DbNewsletterRepository
 
 logger = logging.getLogger(__name__)
@@ -26,7 +28,7 @@ def remove_newsletter_feedback(body: str, *, disable_links: bool = False, remove
                 link.attrs["target"] = "_blank"
                 link.attrs["rel"] = "noopener noreferrer"
 
-    return str(soup)
+    return embeddable_newsletter_html(soup)
 
 
 def remove_newsletter_footers(soup):
@@ -35,6 +37,17 @@ def remove_newsletter_footers(soup):
 
     for feedback_block in soup.find_all("div", class_="newsletter_feedback"):
         feedback_block.decompose()
+
+
+def embeddable_newsletter_html(soup: BeautifulSoup) -> str:
+    style_tags = "".join(str(style_tag) for style_tag in soup.find_all("style"))
+    body = soup.body
+
+    if body is None:
+        return str(soup)
+
+    body_contents = "".join(str(child) for child in body.contents)
+    return f"{style_tags}{body_contents}"
 
 
 def newsletter_preview_context(
@@ -47,7 +60,7 @@ def newsletter_preview_context(
 ) -> dict | None:
     parsed_newsletter_id = UUID(str(newsletter_id)) if newsletter_id else None
     parsed_account_id = UUID(str(account_id)) if account_id else None
-    body_html = newsletter_repo.fetch_newsletter_preview(parsed_newsletter_id, parsed_account_id)
+    body_html = fetch_newsletter_preview_html(newsletter_repo, parsed_newsletter_id, parsed_account_id)
 
     if body_html is None:
         return None
@@ -57,3 +70,28 @@ def newsletter_preview_context(
             body_html, disable_links=disable_links, remove_footer=remove_footer
         ),
     }
+
+
+def fetch_newsletter_preview_html(
+    newsletter_repo: DbNewsletterRepository,
+    newsletter_id: UUID | None = None,
+    account_id: UUID | None = None,
+) -> str | None:
+    if newsletter_id:
+        newsletters_table = newsletter_repo.tables["newsletters"]
+        clauses = [newsletters_table.c.newsletter_id == newsletter_id]
+        if account_id:
+            clauses.append(newsletters_table.c.account_id == account_id)
+
+        query = select(newsletters_table.c.html).where(and_(*clauses)).limit(1)
+        row = newsletter_repo.conn.execute(query).fetchone()
+        return row.html if row else None
+
+    if account_id:
+        newsletter = newsletter_repo.fetch_most_recent_newsletter(
+            account_id,
+            datetime(1970, 1, 1, tzinfo=timezone.utc),
+        )
+        return newsletter.body_html if newsletter else None
+
+    return None


### PR DESCRIPTION
This branch fetches changes from `sophia/create-sample-newsletter` and extends them to integrate multiple tabs for different types of sample_newsletter into the enroll page. The page now directly takes HTML content and embeds it into the enroll preview box. For Create Your Own, it currently just redirects to the email. This will be updated later based on further discussion.
<img width="1902" height="977" alt="Screenshot 2026-04-28 191751" src="https://github.com/user-attachments/assets/58cac010-d0c8-4ab6-b6ab-1ba82592cb64" />

